### PR TITLE
Fix dbname

### DIFF
--- a/templates/model.rb.j2
+++ b/templates/model.rb.j2
@@ -23,7 +23,11 @@ end
   #
   database MySQL, :"{{ dbs.name }}" do |db|
     # To dump all databases, set `db.name = :all` (or leave blank)
-    db.name               = "{{ dbs.db | d(':all') }}"
+    {% if dbs.db == 'all' %}
+    db.name               = :all
+    {% else %}
+    db.name               = "{{ dbs.db }}"
+    {% endif %}
     db.username           = "{{ dbs.username }}"
 {% if dbs.password is defined %}
     db.password           = "{{ dbs.password }}"
@@ -47,7 +51,11 @@ end
   #
   database PostgreSQL, ":{{ dbs.name }}" do |db|
     # To dump all databases, set `db.name = :all` (or leave blank)
+    {% if dbs.db == 'all' %}
+    db.name               = :all
+    {% else %}
     db.name               = "{{ dbs.db }}"
+    {% endif %}
     db.username           = "{{ dbs.username | d('postgres') }}"
 {% if dbs.password is defined %}
     db.password           = "{{ dbs.password }}"

--- a/templates/model.rb.j2
+++ b/templates/model.rb.j2
@@ -23,10 +23,10 @@ end
   #
   database MySQL, :"{{ dbs.name }}" do |db|
     # To dump all databases, set `db.name = :all` (or leave blank)
-    {% if dbs.db == 'all' %}
-    db.name               = :all
-    {% else %}
+    {% if dbs.db is defined %}
     db.name               = "{{ dbs.db }}"
+    {% else %}
+    db.name               = :all
     {% endif %}
     db.username           = "{{ dbs.username }}"
 {% if dbs.password is defined %}
@@ -51,10 +51,10 @@ end
   #
   database PostgreSQL, ":{{ dbs.name }}" do |db|
     # To dump all databases, set `db.name = :all` (or leave blank)
-    {% if dbs.db == 'all' %}
-    db.name               = :all
-    {% else %}
+    {% if dbs.db is defined %}
     db.name               = "{{ dbs.db }}"
+    {% else %}
+    db.name               = :all
     {% endif %}
     db.username           = "{{ dbs.username | d('postgres') }}"
 {% if dbs.password is defined %}


### PR DESCRIPTION
"{{ dbs.db | d(':all') }}" - resulted as ":all", which means make a backup for database name ":all" when DB name does not set
{{ dbs.db | d(':all') }} - results as :all when DB name does not set - works ok. But if DB name set postgres for exapmle, it results db.name = postgres - no quotes. And config validation is failed
Test on version 5.0.0.beta.3